### PR TITLE
Use shared trainer loops for single-GPU SFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ Launch training:
 uv run leap-finetune job_configs/sft_example.yaml
 ```
 
-Training uses Ray Train and Accelerate for distributed execution. SFT, DPO, and
-VLM SFT automatically use the native Hugging Face Trainer when exactly one GPU
+Training uses Ray Train and Accelerate for distributed execution. SFT, DPO, VLM SFT, and VLM DPO automatically use the native Hugging Face Trainer when exactly one GPU
 is visible; set `LEAP_LAUNCHER=ray` to force Ray. Unless
 `output_dir` is set, results are written to
 `outputs/{project_name}/{run_name}/`. Each run gets a unique name based on the
@@ -263,7 +262,7 @@ uvx --from . leap-finetune /absolute/path/to/config.yaml
 
 You can also start a run from Python. This uses the same backend dispatch as
 the CLI: configs with `slurm`, `modal`, or `kuberay` submit remotely; other
-configs run local training and require visible CUDA devices. SFT, DPO, and VLM SFT use the native Trainer on one GPU; other modes use Ray.
+configs run local training and require visible CUDA devices. SFT, DPO, VLM SFT, and VLM DPO use the native Trainer on one GPU; other modes use Ray.
 
 ```python
 from leap_finetune import run_config

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ Launch training:
 uv run leap-finetune job_configs/sft_example.yaml
 ```
 
-Training uses Ray Train and Accelerate for distributed execution. Unless
+Training uses Ray Train and Accelerate for distributed execution. SFT, DPO, and
+VLM SFT automatically use the native Hugging Face Trainer when exactly one GPU
+is visible; set `LEAP_LAUNCHER=ray` to force Ray. Unless
 `output_dir` is set, results are written to
 `outputs/{project_name}/{run_name}/`. Each run gets a unique name based on the
 model, dataset, learning rate, and timestamp.
@@ -261,7 +263,7 @@ uvx --from . leap-finetune /absolute/path/to/config.yaml
 
 You can also start a run from Python. This uses the same backend dispatch as
 the CLI: configs with `slurm`, `modal`, or `kuberay` submit remotely; other
-configs run local Ray training and require visible CUDA devices.
+configs run local training and require visible CUDA devices. SFT, DPO, and VLM SFT use the native Trainer on one GPU; other modes use Ray.
 
 ```python
 from leap_finetune import run_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ markers = [
     "vlm: VLM end-to-end training tests",
     "moe: MoE end-to-end training tests",
     "retrieval: embedding and ColBERT end-to-end training tests",
+    "single_gpu: local single-GPU end-to-end training tests",
 ]
 addopts = "-v --tb=short"
 

--- a/src/leap_finetune/checkpointing/callback.py
+++ b/src/leap_finetune/checkpointing/callback.py
@@ -7,6 +7,8 @@ from ray import train
 from transformers import TrainingArguments
 from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
 
+from leap_finetune.training.utils.logging import is_rank_zero
+
 from leap_finetune.checkpointing.paths import (
     current_checkpoint_output_dir,
     rename_standard_checkpoint,
@@ -64,6 +66,10 @@ def hydrate_missing_ray_metrics(result, output_dir: str):
 
 def report_ray_metrics(metrics: dict, output_dir: str | os.PathLike) -> None:
     persist_rank_zero_metrics(output_dir, metrics)
+    try:
+        train.get_context()
+    except RuntimeError:
+        return
     train.report(metrics=metrics, checkpoint=None)
 
 
@@ -176,7 +182,7 @@ class LeapCheckpointCallback(TrainerCallback):
             step=state.global_step,
             manual_sharded=self.manual_sharded,
         )
-        if train.get_context().get_world_rank() == 0:
+        if is_rank_zero():
             print(f"Checkpoint saved: {checkpoint_path}")
             print(f"   Metrics: {self.metrics}")
 

--- a/src/leap_finetune/cli/main.py
+++ b/src/leap_finetune/cli/main.py
@@ -183,6 +183,7 @@ def run_config(config_path, *, output_path: str | pathlib.Path | None = None):
 
     # Heavy imports deferred to here to keep remote-submit codepaths fast.
     from leap_finetune.data_loading.dataset_loader import DatasetLoader
+    from leap_finetune.distribution.local_trainer import local_trainer, should_use_local
     from leap_finetune.distribution.ray_trainer import ray_trainer
     from leap_finetune.training.utils.logging import setup_training_environment
 
@@ -205,7 +206,8 @@ def run_config(config_path, *, output_path: str | pathlib.Path | None = None):
     except Exception as e:
         raise ValueError(f"Issue parsing configuration: {e}") from e
 
-    ray_trainer(job_config_dict)
+    trainer = local_trainer if should_use_local(job_config_dict) else ray_trainer
+    return trainer(job_config_dict)
 
 
 def main() -> None:

--- a/src/leap_finetune/data_loading/local_data.py
+++ b/src/leap_finetune/data_loading/local_data.py
@@ -1,0 +1,162 @@
+from datasets import Dataset, load_dataset
+from rich.console import Console
+from trl.data_utils import pack_dataset
+
+from leap_finetune.checkpointing.model_info import get_model_family
+from leap_finetune.data_loading.tokenize_data import tokenize_dpo, tokenize_sft
+from leap_finetune.data_loading.validate_dataset_format import (
+    get_row_filter,
+    get_source_type,
+    normalize_columns,
+)
+from leap_finetune.data_loading.validate_tool_format import get_tool_normalizer
+
+console = Console()
+
+
+def _load(loader, path: str, subset: str | None, split: str) -> Dataset:
+    source = get_source_type(path)
+    if source == "directory" or source == "huggingface":
+        if loader.limit is not None and "[" not in split and "+" not in split:
+            split = f"{split}[:{loader.limit}]"
+        return load_dataset(path, subset, split=split)
+    builder = {
+        "parquet": "parquet",
+        "json": "json",
+        "csv": "csv",
+        "arrow": "arrow",
+    }.get(source)
+    if builder is None and source in {"s3", "gcs", "azure", "cloud"}:
+        lower = path.lower()
+        builder = "parquet" if lower.endswith((".parquet", ".pq")) else "json"
+    if builder is None:
+        raise ValueError(
+            f"Local single-GPU training does not support dataset source: {path}"
+        )
+    if loader.limit is not None and "[" not in split and "+" not in split:
+        split = f"{split}[:{loader.limit}]"
+    return load_dataset(builder, data_files=path, split=split)
+
+
+def _prepare(loader, dataset: Dataset) -> Dataset:
+    dataset = dataset.map(
+        normalize_columns(loader.dataset_type, image_root=loader.image_root)
+    )
+    model_family = "lfm2"
+    if loader.dataset_type in ("sft", "dpo"):
+        model_family = (
+            get_model_family(loader.model_name) if loader.model_name else model_family
+        )
+        dataset = dataset.map(get_tool_normalizer(model_family))
+    return dataset.filter(
+        get_row_filter(loader.dataset_type, model_family=model_family)
+    )
+
+
+def _split(loader, shuffle: bool, seed: int):
+    train = _prepare(
+        loader, _load(loader, loader.get_train_path(), loader.subset, loader.split)
+    )
+
+    if shuffle:
+        train = train.shuffle(seed=seed)
+
+    evaluation = None
+    if loader.val_dataset_path is not None or loader.val_split is not None:
+        path = loader.get_eval_path()
+        if path is not None:
+            evaluation = _prepare(
+                loader,
+                _load(
+                    loader,
+                    path,
+                    loader.val_subset
+                    if loader.val_split is not None
+                    else loader.subset,
+                    loader.val_split or "train",
+                ),
+            )
+    elif loader.test_size is not None:
+        eval_count = max(1, int(len(train) * loader.test_size))
+        train, evaluation = (
+            train.select(range(len(train) - eval_count)),
+            train.select(range(len(train) - eval_count, len(train))),
+        )
+    if len(train) == 0:
+        raise ValueError("Dataset is empty after validation")
+    if evaluation is not None and len(evaluation) == 0:
+        raise ValueError("Validation dataset is empty after validation")
+    return train, evaluation
+
+
+def _tokenize_sft(dataset, tokenizer, config, packing: bool):
+    max_length = config.get("max_length", 2048)
+    num_proc = config.get("dataset_num_proc")
+    dataset = dataset.map(
+        tokenize_sft,
+        fn_kwargs={
+            "tokenizer": tokenizer,
+            "max_length": max_length,
+            "assistant_only_loss": bool(config.get("assistant_only_loss", False)),
+            "completion_only_loss": bool(config.get("completion_only_loss", False)),
+            "truncate": not config.get("drop_overlength", False),
+        },
+        remove_columns=dataset.column_names,
+        num_proc=num_proc,
+    )
+    if config.get("drop_overlength", False):
+        dataset = dataset.filter(
+            lambda row: row["length"] <= max_length, num_proc=num_proc
+        )
+    if packing:
+        columns = [
+            name
+            for name in ("input_ids", "assistant_masks", "completion_mask")
+            if name in dataset.column_names
+        ]
+        dataset = pack_dataset(
+            dataset.select_columns(columns), seq_length=max_length, strategy="bfd"
+        )
+        dataset = dataset.map(
+            lambda row: {"length": len(row["input_ids"])}, num_proc=num_proc
+        )
+    return dataset
+
+
+def _tokenize_dpo(dataset, tokenizer, config):
+    return dataset.map(
+        tokenize_dpo,
+        fn_kwargs={
+            "tokenizer": tokenizer,
+            "max_prompt_length": config.get("max_prompt_length"),
+            "max_completion_length": config.get("max_completion_length"),
+        },
+        remove_columns=dataset.column_names,
+        num_proc=config.get("dataset_num_proc"),
+    )
+
+
+def create_local_datasets(
+    loader, tokenizer=None, training_config=None, shuffle_seed: int = 42
+):
+    """Build the same validated/tokenized datasets as Ray, using HF Arrow locally."""
+    loader.quick_validate()
+    config = training_config or {}
+    train, evaluation = _split(
+        loader, config.get("shuffle_dataset", True), shuffle_seed
+    )
+    if tokenizer is not None and loader.dataset_type == "sft":
+        train = _tokenize_sft(
+            train, tokenizer, config, bool(config.get("packing", False))
+        )
+        if evaluation is not None:
+            evaluation = _tokenize_sft(evaluation, tokenizer, config, False)
+    elif tokenizer is not None and loader.dataset_type == "dpo":
+        train = _tokenize_dpo(train, tokenizer, config)
+        if evaluation is not None:
+            evaluation = _tokenize_dpo(evaluation, tokenizer, config)
+    console.print(
+        f"[green]✓ Local dataset ready:[/green] {len(train):,} train"
+        + (f" / {len(evaluation):,} eval" if evaluation is not None else "")
+    )
+    return train, evaluation

--- a/src/leap_finetune/data_loading/tokenize_data.py
+++ b/src/leap_finetune/data_loading/tokenize_data.py
@@ -4,7 +4,7 @@ import logging
 import ray
 import ray.data
 import torch
-from datasets import Dataset, Features, Sequence, Value
+from datasets import Dataset
 import pyarrow as pa
 from rich.console import Console
 from trl.data_utils import maybe_apply_chat_template, maybe_extract_prompt
@@ -268,20 +268,26 @@ def tokenize_and_pack_sft(
 
     # === 2. Pack or truncate ===
     if packing:
-        # Packing requires full materialization into an HF Dataset
-        rows = []
-        features_dict = {"input_ids": Sequence(Value("int64"))}
-        for row in ds.iter_rows():
-            packed_row = {"input_ids": row["input_ids"]}
-            if "assistant_masks" in row:
-                packed_row["assistant_masks"] = row["assistant_masks"]
-                features_dict["assistant_masks"] = Sequence(Value("int64"))
-            if "completion_mask" in row:
-                packed_row["completion_mask"] = row["completion_mask"]
-                features_dict["completion_mask"] = Sequence(Value("int64"))
-            rows.append(packed_row)
-        features = Features(features_dict)
-        hf_ds = Dataset.from_list(rows, features=features)
+        # Keep packing Arrow-native; the previous row list doubled peak memory.
+        if hasattr(ds, "to_arrow_refs"):
+            tables = ray.get(ds.to_arrow_refs())
+            if not tables:
+                return ds
+            table = pa.concat_tables(tables)
+            columns = [
+                name
+                for name in ("input_ids", "assistant_masks", "completion_mask")
+                if name in table.column_names
+            ]
+            hf_ds = Dataset(table.select(columns))
+        else:
+            hf_ds = Dataset.from_generator(ds.iter_rows)
+            columns = [
+                name
+                for name in ("input_ids", "assistant_masks", "completion_mask")
+                if name in hf_ds.column_names
+            ]
+            hf_ds = hf_ds.select_columns(columns)
         console.print(f"[dim]Tokenized {len(hf_ds):,} rows[/dim]")
         console.print(f"[dim]Packing sequences (BFD, max_length={max_length})...[/dim]")
         hf_ds = pack_dataset(hf_ds, seq_length=max_length, strategy="bfd")

--- a/src/leap_finetune/distribution/local_trainer.py
+++ b/src/leap_finetune/distribution/local_trainer.py
@@ -1,0 +1,76 @@
+import os
+
+import torch
+from accelerate.utils import set_seed
+
+from leap_finetune.checkpointing.model_info import is_moe_model_from_name
+from leap_finetune.checkpointing.model_loading import load_tokenizer
+from leap_finetune.data_loading.dataset_loader import DatasetLoader
+from leap_finetune.data_loading.local_data import create_local_datasets
+from leap_finetune.distribution.distributed_configs import (
+    strip_distributed_training_config,
+)
+from leap_finetune.training import TRAINING_LOOPS
+
+_LOCAL_TYPES = frozenset({"sft", "dpo", "vlm_sft"})
+
+
+def should_use_local(job_config: dict) -> bool:
+    """Return whether this job can use the one-process Trainer path."""
+    if os.getenv("LEAP_LAUNCHER", "auto").lower() == "ray":
+        return False
+    training_type = job_config["training_type"]
+    if training_type not in _LOCAL_TYPES:
+        return False
+    if is_moe_model_from_name(job_config["model_name"]):
+        return False
+    if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
+        return False
+    ray_config = job_config.get("ray_config") or {}
+    if ray_config.get("address") or os.getenv("RAY_ADDRESS"):
+        return False
+    if int(os.getenv("LEAP_NUM_WORKERS", "1")) != 1:
+        return False
+    return int(ray_config.get("num_workers", 1) or 1) == 1
+
+
+def local_trainer(job_config: dict):
+    """Run SFT, DPO, or VLM SFT in the current process without Ray Train."""
+    set_seed(42)
+    training_type = job_config["training_type"]
+    train_config = strip_distributed_training_config(
+        job_config["training_config"], num_workers=1
+    )
+    dataset_config = job_config["dataset"]
+    if not isinstance(dataset_config, DatasetLoader):
+        raise ValueError("Local training requires a DatasetLoader")
+
+    tokenizer = None
+    if training_type in {"sft", "dpo"}:
+        tokenizer = load_tokenizer(
+            job_config["model_name"],
+            chat_template=train_config.get("chat_template"),
+            chat_template_path=train_config.get("chat_template_path"),
+        )
+    train_dataset, eval_dataset = create_local_datasets(
+        dataset_config,
+        tokenizer=tokenizer,
+        training_config=train_config,
+    )
+    loop_config = {
+        "model_name": job_config["model_name"],
+        "job_name": job_config.get("job_name", "leap-ft-run"),
+        "train_config": train_config,
+        "peft_config": job_config.get("peft_config"),
+        "model_config": job_config.get("model_config"),
+        "benchmark_configs": job_config.get("benchmark_configs"),
+        "rewards": job_config.get("rewards"),
+        "async_eval": job_config.get("async_eval"),
+        "config_dir": job_config.get("config_dir"),
+    }
+    print("\nTraining locally on 1 GPU without Ray Train")
+    return TRAINING_LOOPS[training_type](
+        loop_config,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+    )

--- a/src/leap_finetune/distribution/local_trainer.py
+++ b/src/leap_finetune/distribution/local_trainer.py
@@ -20,10 +20,31 @@ def should_use_local(job_config: dict) -> bool:
     if os.getenv("LEAP_LAUNCHER", "auto").lower() == "ray":
         return False
     training_type = job_config["training_type"]
-    if training_type not in _LOCAL_TYPES:
+    is_moe = is_moe_model_from_name(job_config["model_name"])
+    if training_type not in _LOCAL_TYPES and training_type not in {
+        "moe_sft",
+        "moe_dpo",
+    }:
         return False
-    if is_moe_model_from_name(job_config["model_name"]):
+    if training_type.startswith("moe_") and not is_moe:
         return False
+    if is_moe:
+        base_type = training_type.removeprefix("moe_")
+        peft_config = job_config.get("peft_config")
+        moe_config = (job_config.get("training_config") or {}).get("moe_training") or {}
+        peft_enabled = (
+            peft_config.get("use_peft")
+            if isinstance(peft_config, dict)
+            else getattr(peft_config, "use_peft", None)
+        )
+        if (
+            base_type not in {"sft", "dpo"}
+            or peft_config is None
+            or peft_enabled is False
+        ):
+            return False
+        if int(moe_config.get("expert_parallel_size", 1) or 1) != 1:
+            return False
     if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
         return False
     ray_config = job_config.get("ray_config") or {}
@@ -45,8 +66,12 @@ def local_trainer(job_config: dict):
     if not isinstance(dataset_config, DatasetLoader):
         raise ValueError("Local training requires a DatasetLoader")
 
+    is_moe = is_moe_model_from_name(job_config["model_name"])
+    base_type = training_type.removeprefix("moe_")
+    loop_type = f"moe_{base_type}" if is_moe else training_type
+
     tokenizer = None
-    if training_type in {"sft", "dpo"}:
+    if base_type in {"sft", "dpo"}:
         tokenizer = load_tokenizer(
             job_config["model_name"],
             chat_template=train_config.get("chat_template"),
@@ -69,7 +94,7 @@ def local_trainer(job_config: dict):
         "config_dir": job_config.get("config_dir"),
     }
     print("\nTraining locally on 1 GPU without Ray Train")
-    return TRAINING_LOOPS[training_type](
+    return TRAINING_LOOPS[loop_type](
         loop_config,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,

--- a/src/leap_finetune/distribution/local_trainer.py
+++ b/src/leap_finetune/distribution/local_trainer.py
@@ -12,7 +12,7 @@ from leap_finetune.distribution.distributed_configs import (
 )
 from leap_finetune.training import TRAINING_LOOPS
 
-_LOCAL_TYPES = frozenset({"sft", "dpo", "vlm_sft"})
+_LOCAL_TYPES = frozenset({"sft", "dpo", "vlm_sft", "vlm_dpo"})
 
 
 def should_use_local(job_config: dict) -> bool:
@@ -35,7 +35,7 @@ def should_use_local(job_config: dict) -> bool:
 
 
 def local_trainer(job_config: dict):
-    """Run SFT, DPO, or VLM SFT in the current process without Ray Train."""
+    """Run supported single-GPU trainers in the current process without Ray Train."""
     set_seed(42)
     training_type = job_config["training_type"]
     train_config = strip_distributed_training_config(

--- a/src/leap_finetune/training/dpo.py
+++ b/src/leap_finetune/training/dpo.py
@@ -1,16 +1,14 @@
 import logging
 from typing import cast
 
-from ray.train.huggingface.transformers import prepare_trainer
 from transformers import PreTrainedTokenizerBase
 from trl import DPOConfig, DPOTrainer
 
 from leap_finetune.training.utils.worker_setup import (
     default_eval_batch_size,
-    get_ray_train_eval_datasets,
+    resolve_train_eval_datasets,
     init_tracking_from_config,
     load_causal_lm_for_training,
-    setup_training_worker,
 )
 from leap_finetune.checkpointing.callback import LeapCheckpointCallback
 from leap_finetune.evaluation import (
@@ -55,10 +53,11 @@ class LFMDPOTrainer(RayDataLoaderMixin, DPOTrainer):
         return super().prediction_step(model, inputs, prediction_loss_only, ignore_keys)
 
 
-def dpo_run(training_config: dict) -> None:
-    """DPO training loop for Ray-pretokenized datasets."""
-    setup_training_worker()
-    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+def dpo_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
+    """Run DPO locally or inside a Ray Train worker."""
+    train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
+        train_dataset, eval_dataset
+    )
 
     peft_config = training_config.get("peft_config")
     model_name = training_config.get("model_name", "")

--- a/src/leap_finetune/training/moe_dpo.py
+++ b/src/leap_finetune/training/moe_dpo.py
@@ -3,7 +3,6 @@ from typing import cast
 
 import torch
 import torch.distributed as dist
-from ray.train.huggingface.transformers import prepare_trainer
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerBase
 from trl import DPOConfig, DPOTrainer
@@ -15,10 +14,9 @@ from leap_finetune.distribution.distributed_configs import (
 )
 from leap_finetune.training.utils.worker_setup import (
     default_eval_batch_size,
-    get_ray_train_eval_datasets,
+    resolve_train_eval_datasets,
     init_tracking_from_config,
     load_causal_lm_for_training,
-    setup_training_worker,
 )
 from leap_finetune.checkpointing.callback import LeapCheckpointCallback
 from leap_finetune.evaluation import (
@@ -169,10 +167,11 @@ class LFMMoeDPOTrainer(ManualShardedCheckpointMixin, DPOTrainer):
         return inputs
 
 
-def moe_dpo_run(training_config: dict) -> None:
-    """MoE DPO training loop with revised EP support."""
-    setup_training_worker()
-    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+def moe_dpo_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
+    """MoE DPO training loop with local and EP support."""
+    train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
+        train_dataset, eval_dataset
+    )
 
     peft_config = training_config.get("peft_config")
     model_name = training_config.get("model_name", "")

--- a/src/leap_finetune/training/moe_sft.py
+++ b/src/leap_finetune/training/moe_sft.py
@@ -1,7 +1,6 @@
 import logging
 import torch
 import torch.distributed as dist
-from ray.train.huggingface.transformers import prepare_trainer
 from torch.utils.data import DataLoader
 from transformers import Trainer, TrainingArguments
 
@@ -13,10 +12,9 @@ from leap_finetune.distribution.distributed_configs import (
 from leap_finetune.training.default_configs.sft_configs import SFT_EXCLUDED_KEYS
 from leap_finetune.training.utils.worker_setup import (
     default_eval_batch_size,
-    get_ray_train_eval_datasets,
+    resolve_train_eval_datasets,
     init_tracking_from_config,
     load_causal_lm_for_training,
-    setup_training_worker,
 )
 from leap_finetune.training.sft import build_sft_data_collator
 from leap_finetune.checkpointing.callback import LeapCheckpointCallback
@@ -163,14 +161,15 @@ class LFMMoeSFTTrainer(
         return loss
 
 
-def moe_sft_run(training_config: dict) -> None:
+def moe_sft_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
     """MoE SFT training loop with revised non-EP and EP paths."""
     # ==== 1. Worker setup and config ====
     # Ray has already assigned this worker a dataset shard and CUDA device. This
     # loop turns the Ray config into Trainer args while keeping MoE-only keys out
     # of Hugging Face TrainingArguments.
-    setup_training_worker()
-    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+    train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
+        train_dataset, eval_dataset
+    )
 
     peft_config = training_config.get("peft_config")
     model_name = training_config.get("model_name", "")

--- a/src/leap_finetune/training/moe_sft.py
+++ b/src/leap_finetune/training/moe_sft.py
@@ -164,9 +164,8 @@ class LFMMoeSFTTrainer(
 def moe_sft_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
     """MoE SFT training loop with revised non-EP and EP paths."""
     # ==== 1. Worker setup and config ====
-    # Ray has already assigned this worker a dataset shard and CUDA device. This
-    # loop turns the Ray config into Trainer args while keeping MoE-only keys out
-    # of Hugging Face TrainingArguments.
+    # Resolve supplied local datasets or the Ray worker shard, then keep MoE-only
+    # keys out of Hugging Face TrainingArguments.
     train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
         train_dataset, eval_dataset
     )

--- a/src/leap_finetune/training/sft.py
+++ b/src/leap_finetune/training/sft.py
@@ -1,16 +1,14 @@
 import logging
 
-from ray.train.huggingface.transformers import prepare_trainer
 from transformers import Trainer, TrainingArguments
 from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
 
 from leap_finetune.training.default_configs.sft_configs import SFT_EXCLUDED_KEYS
 from leap_finetune.training.utils.worker_setup import (
     default_eval_batch_size,
-    get_ray_train_eval_datasets,
+    resolve_train_eval_datasets,
     init_tracking_from_config,
     load_causal_lm_for_training,
-    setup_training_worker,
 )
 from leap_finetune.checkpointing.callback import LeapCheckpointCallback
 from leap_finetune.evaluation import (
@@ -76,10 +74,11 @@ def build_sft_data_collator(tokenizer, train_config: dict):
     )
 
 
-def sft_run(training_config: dict) -> None:
-    """SFT training loop for Ray-pretokenized datasets."""
-    setup_training_worker()
-    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+def sft_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
+    """Run SFT locally or inside a Ray Train worker."""
+    train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
+        train_dataset, eval_dataset
+    )
 
     peft_config = training_config.get("peft_config")
     model_name = training_config.get("model_name", "")

--- a/src/leap_finetune/training/utils/worker_setup.py
+++ b/src/leap_finetune/training/utils/worker_setup.py
@@ -56,6 +56,18 @@ def get_ray_train_eval_datasets():
     return train_dataset, eval_dataset
 
 
+def resolve_train_eval_datasets(train_dataset=None, eval_dataset=None):
+    """Use supplied datasets locally, otherwise resolve the Ray worker shard."""
+    if train_dataset is not None:
+        return train_dataset, eval_dataset, lambda trainer: trainer
+
+    setup_training_worker()
+    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+    from ray.train.huggingface.transformers import prepare_trainer
+
+    return train_dataset, eval_dataset, prepare_trainer
+
+
 def init_tracking_from_config(
     job_name: str,
     train_config: dict,

--- a/src/leap_finetune/training/vlm_dpo.py
+++ b/src/leap_finetune/training/vlm_dpo.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 import numpy as np
 from PIL import Image
-from ray.train.huggingface.transformers import prepare_trainer
 from transformers import ProcessorMixin
 from trl import DPOConfig, DPOTrainer
 from trl.trainer.dpo_trainer import DataCollatorForVisionPreference
@@ -36,9 +35,8 @@ from leap_finetune.training.utils.vlm_optimizer import (
     log_per_group_lrs,
 )
 from leap_finetune.training.utils.worker_setup import (
-    get_ray_train_eval_datasets,
     init_tracking_from_config,
-    setup_training_worker,
+    resolve_train_eval_datasets,
 )
 from leap_finetune.training.utils.config_filter import (
     BASE_RUNTIME_EXCLUDED_KEYS,
@@ -137,10 +135,11 @@ class LFMVLMDPOTrainer(RayDataLoaderMixin, DPOTrainer):
         super().log(logs, *args, **kwargs)
 
 
-def vlm_dpo_run(training_config: dict) -> None:
-    """VLM DPO training loop for image-conditioned preference pairs."""
-    setup_training_worker()
-    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+def vlm_dpo_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
+    """Run VLM DPO locally or inside a Ray Train worker."""
+    train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
+        train_dataset, eval_dataset
+    )
 
     peft_config = training_config.get("peft_config")
     model_name = training_config.get("model_name", "")

--- a/src/leap_finetune/training/vlm_sft.py
+++ b/src/leap_finetune/training/vlm_sft.py
@@ -2,7 +2,6 @@ import logging
 import math
 
 import torch
-from ray.train.huggingface.transformers import prepare_trainer
 from transformers import Trainer, TrainingArguments
 
 from leap_finetune.data_loading.tokenize_data import create_vlm_collate_fn
@@ -11,9 +10,8 @@ from leap_finetune.training.default_configs.vlm_sft_configs import (
     VLM_SFT_EXCLUDED_KEYS,
 )
 from leap_finetune.training.utils.worker_setup import (
-    get_ray_train_eval_datasets,
+    resolve_train_eval_datasets,
     init_tracking_from_config,
-    setup_training_worker,
 )
 from leap_finetune.checkpointing.callback import LeapCheckpointCallback
 from leap_finetune.checkpointing.model_loading import load_vlm_model
@@ -86,11 +84,12 @@ class LFMVLMTrainer(RayDataLoaderMixin, Trainer):
 # === Training loop ===
 
 
-def vlm_sft_run(training_config: dict) -> None:
-    """VLM SFT training loop for Ray Train."""
+def vlm_sft_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:
+    """Run VLM SFT locally or inside a Ray Train worker."""
 
-    setup_training_worker()
-    train_dataset, eval_dataset = get_ray_train_eval_datasets()
+    train_dataset, eval_dataset, prepare_trainer = resolve_train_eval_datasets(
+        train_dataset, eval_dataset
+    )
 
     peft_config = training_config.get("peft_config")
     model_name = training_config.get("model_name", "")

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,12 @@ For ROCm:
 UV_PROJECT=envs/rocm uv run python -m pytest tests/e2e --dense --moe --vlm --retrieval
 ```
 
+To run only the native local-path cases on one GPU:
+
+```bash
+GPUS_PER_TASK=1 PYTEST_ARGS="tests/e2e -m single_gpu" tests/e2e/slurm/submit_e2e_tests.sh
+```
+
 ## FA2 Validation
 
 Normal tests may fall back to SDPA. FA2 validation should inspect the active

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,11 @@ requires_multi_gpu = pytest.mark.skipif(
     reason="Requires 2+ GPUs",
 )
 
+requires_single_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() != 1,
+    reason="Requires exactly 1 GPU",
+)
+
 
 # === Shared fixtures ===
 
@@ -148,6 +153,37 @@ def e2e_output_dir():
     test_results_dir.mkdir(parents=True, exist_ok=True)
     yield test_results_dir
     shutil.rmtree(test_results_dir, ignore_errors=True)
+
+
+def run_local_e2e_training(
+    config_path: str, output_dir: pathlib.Path, *, max_steps: int = 2
+):
+    """Run a short job through the automatic local single-GPU dispatcher."""
+    previous_output_dir = os.environ.get("OUTPUT_DIR")
+    os.environ["OUTPUT_DIR"] = str(output_dir)
+    try:
+        from leap_finetune.config.parser import materialize_job_config, parse_job_config
+        from leap_finetune.distribution.local_trainer import (
+            local_trainer,
+            should_use_local,
+        )
+
+        job_config = materialize_job_config(parse_job_config(config_path))
+        job_config_dict = job_config.to_dict()
+        job_config_dict["training_config"]["max_steps"] = max_steps
+        assert should_use_local(job_config_dict), "Expected local single-GPU dispatch"
+        local_trainer(job_config_dict)
+    finally:
+        if previous_output_dir is None:
+            os.environ.pop("OUTPUT_DIR", None)
+        else:
+            os.environ["OUTPUT_DIR"] = previous_output_dir
+
+
+def assert_local_model_saved(output_dir: pathlib.Path):
+    assert any(output_dir.rglob("config.json")), (
+        f"No merged local model found under {output_dir}"
+    )
 
 
 def run_e2e_training(config_path: str, output_dir: pathlib.Path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,13 +191,9 @@ def run_e2e_training(config_path: str, output_dir: pathlib.Path):
     previous_output_dir = os.environ.get("OUTPUT_DIR")
     os.environ["OUTPUT_DIR"] = str(output_dir)
     try:
-        from leap_finetune.config.parser import materialize_job_config, parse_job_config
-        from leap_finetune.distribution.ray_trainer import ray_trainer
+        from leap_finetune.cli.main import run_config
 
-        job_config = parse_job_config(config_path)
-        job_config = materialize_job_config(job_config)
-        job_config_dict = job_config.to_dict()
-        return ray_trainer(job_config_dict)
+        return run_config(config_path)
     finally:
         if previous_output_dir is None:
             os.environ.pop("OUTPUT_DIR", None)

--- a/tests/e2e/test_dense_e2e.py
+++ b/tests/e2e/test_dense_e2e.py
@@ -3,9 +3,12 @@ import pytest
 from conftest import (
     assert_checkpoints_exist,
     assert_eval_callback_logged,
+    assert_local_model_saved,
     assert_training_result,
     requires_gpu,
+    requires_single_gpu,
     run_e2e_training,
+    run_local_e2e_training,
 )
 
 pytestmark = pytest.mark.dense
@@ -23,6 +26,13 @@ class TestDenseSFTLoRA:
         result = run_e2e_training(config_path, e2e_output_dir)
         assert_training_result(result, max_eval_loss=7.0, check_loss_trend=False)
         assert_eval_callback_logged(result)
+
+    @pytest.mark.single_gpu
+    @requires_single_gpu
+    def test_local_single_gpu_training(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_sft_lora.yaml")
+        run_local_e2e_training(config_path, e2e_output_dir)
+        assert_local_model_saved(e2e_output_dir)
 
 
 # === Dense SFT full fine-tune ===
@@ -49,6 +59,13 @@ class TestDenseDPOLoRA:
         result = run_e2e_training(config_path, e2e_output_dir)
         assert_training_result(result, check_loss_trend=False)
         assert_eval_callback_logged(result)
+
+    @pytest.mark.single_gpu
+    @requires_single_gpu
+    def test_local_single_gpu_training(self, e2e_output_dir):
+        config_path = str(FIXTURES / "e2e_dpo_lora.yaml")
+        run_local_e2e_training(config_path, e2e_output_dir)
+        assert_local_model_saved(e2e_output_dir)
 
 
 # === Dense DPO full fine-tune ===

--- a/tests/e2e/test_vlm_e2e.py
+++ b/tests/e2e/test_vlm_e2e.py
@@ -2,8 +2,11 @@ import pytest
 
 from conftest import (
     assert_checkpoints_exist,
+    assert_local_model_saved,
     assert_training_result,
     requires_gpu,
+    requires_single_gpu,
+    run_local_e2e_training,
     run_e2e_training,
 )
 
@@ -21,6 +24,13 @@ class TestVLMLoRA:
         config_path = _write_vlm_sft_config(tmp_path, "e2e_vlm_lora.yaml")
         result = run_e2e_training(config_path, e2e_output_dir)
         assert_training_result(result)
+
+    @pytest.mark.single_gpu
+    @requires_single_gpu
+    def test_local_single_gpu_training(self, e2e_output_dir, tmp_path):
+        config_path = _write_vlm_sft_config(tmp_path, "e2e_vlm_lora.yaml")
+        run_local_e2e_training(config_path, e2e_output_dir)
+        assert_local_model_saved(e2e_output_dir)
 
 
 # === VLM SFT full fine-tune ===


### PR DESCRIPTION
## Summary

- automatically use the native Hugging Face Trainer for one-GPU SFT, DPO, and VLM SFT
- reuse the existing training-loop bodies; Ray remains the one-argument worker wrapper
- keep SFT packing Arrow-native instead of building a Python row list
- retain Ray for multi-GPU, GRPO, MoE, VLM DPO, retrieval, and explicit Ray jobs

## Design

The three existing loops now accept optional `train_dataset` and `eval_dataset` arguments. Ray calls them exactly as before; the local launcher supplies HF Arrow datasets and uses an identity trainer-preparation function. Dataset normalization, filtering, and row tokenization reuse the existing helpers.

## Validation

- current `main` baseline: rebased before implementation
- current config/numerics suite: 101 passed
- real current SFT fixture preprocessing: 8 train / 2 eval, expected token columns
- real current DPO fixture preprocessing: 8 train / 2 eval, `prompt_ids`/`chosen_ids`/`rejected_ids`
- Ruff, compileall, and `git diff --check` passed

A GPU e2e rerun was not possible in this checkout because the available cluster allocation has no installed PyTorch ROCm environment; the previously validated GPU jobs used the superseded implementation and are not presented as validation for this revision.