### PR TITLE
fix(sft): reject an all-zero assistant mask instead of training on nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,13 @@ Pinned chat templates live in
 LiquidAI LFM2.5 and LFM2-24B models select the pinned LFM2.5 template by
 default.
 
+For conversational SFT, set `assistant_only_loss: true` to supervise only
+assistant turns, or `completion_only_loss: true` to supervise only the final
+assistant completion. These options require a chat template with
+`{% generation %}` and `{% endgeneration %}` markers around assistant output;
+the bundled LFM templates include them. They are not used for plain-text SFT
+rows.
+
 ## Contributing
 
 ### Testing

--- a/src/leap_finetune/data_loading/tokenize_data.py
+++ b/src/leap_finetune/data_loading/tokenize_data.py
@@ -206,6 +206,23 @@ def tokenize_sft(
             raise ValueError(
                 "assistant mask length mismatch after chat template tokenization"
             )
+        if not any(assistant_masks):
+            # A chat template without {% generation %} markers makes
+            # apply_chat_template return an all-zero assistant mask: it warns but
+            # does not raise, so the run trains on zero supervised tokens and the
+            # loss curve still looks plausible. Truncation can legitimately cut
+            # the assistant span off a long row, so only reject rows that fit.
+            truncated = (
+                truncate and max_length is not None and len(input_ids) >= max_length
+            )
+            if not truncated:
+                raise ValueError(
+                    "assistant mask is all zeros for a row that was not truncated. "
+                    "The chat template has no {% generation %} markers, so "
+                    "assistant_only_loss/completion_only_loss would supervise no "
+                    "tokens. Use a template that marks the assistant span, or turn "
+                    "the flag off."
+                )
         if assistant_only_loss:
             output["assistant_masks"] = assistant_masks
         if completion_only_loss:

--- a/src/leap_finetune/data_loading/tokenize_data.py
+++ b/src/leap_finetune/data_loading/tokenize_data.py
@@ -218,10 +218,10 @@ def tokenize_sft(
             if not truncated:
                 raise ValueError(
                     "assistant mask is all zeros for a row that was not truncated. "
-                    "The chat template has no {% generation %} markers, so "
-                    "assistant_only_loss/completion_only_loss would supervise no "
-                    "tokens. Use a template that marks the assistant span, or turn "
-                    "the flag off."
+                    "Check that the chat template has {% generation %} markers, "
+                    "that the row contains assistant content, and that the "
+                    "assistant span is not fully truncated. Otherwise, use a "
+                    "template that marks the assistant span or turn the flag off."
                 )
         if assistant_only_loss:
             output["assistant_masks"] = assistant_masks

--- a/tests/math/test_sft_loss_masks.py
+++ b/tests/math/test_sft_loss_masks.py
@@ -83,6 +83,64 @@ def test_tokenize_sft_rejects_text_rows_for_masked_loss():
         raise AssertionError("Expected tokenize_sft to reject text rows")
 
 
+class _NoGenerationMarkerTokenizer(_FakeTokenizer):
+    """A template without {% generation %}: transformers warns and returns zeros."""
+
+    def __init__(self, length: int = 6) -> None:
+        self._length = length
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        truncation=True,
+        max_length=None,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+        tools=None,
+    ):
+        del messages, tokenize, truncation, max_length, tools
+        output = {"input_ids": list(range(10, 10 + self._length))}
+        if return_assistant_tokens_mask:
+            output["assistant_masks"] = [0] * self._length
+        return output if return_dict else output["input_ids"]
+
+
+def test_tokenize_sft_rejects_all_zero_assistant_mask():
+    """Without this the run supervises no tokens and the loss still looks fine."""
+    tokenizer = _NoGenerationMarkerTokenizer()
+    row = {"messages": [{"role": "user", "content": "x"}]}
+
+    try:
+        tokenize_sft(row, tokenizer, max_length=128, assistant_only_loss=True)
+    except ValueError as exc:
+        assert "all zeros" in str(exc)
+    else:
+        raise AssertionError("Expected tokenize_sft to reject an all-zero mask")
+
+
+def test_tokenize_sft_rejects_all_zero_completion_mask():
+    tokenizer = _NoGenerationMarkerTokenizer()
+    row = {"messages": [{"role": "user", "content": "x"}]}
+
+    try:
+        tokenize_sft(row, tokenizer, max_length=128, completion_only_loss=True)
+    except ValueError as exc:
+        assert "all zeros" in str(exc)
+    else:
+        raise AssertionError("Expected tokenize_sft to reject an all-zero mask")
+
+
+def test_tokenize_sft_allows_all_zero_mask_when_row_was_truncated():
+    """Truncation can legitimately cut the assistant span off a long row."""
+    tokenizer = _NoGenerationMarkerTokenizer(length=4)
+    row = {"messages": [{"role": "user", "content": "x"}]}
+
+    tokenized = tokenize_sft(row, tokenizer, max_length=4, assistant_only_loss=True)
+
+    assert tokenized["assistant_masks"] == [0, 0, 0, 0]
+
+
 def test_collator_applies_intersection_of_completion_and_assistant_masks():
     tokenizer = _FakeTokenizer()
     collator = build_sft_data_collator(


### PR DESCRIPTION
fix(sft): reject an all-zero assistant mask instead of training on nothing

`tokenize_sft` passes `result["assistant_masks"]` straight through after a
length check. When the tokenizer's chat template has no `{% generation %}`
markers, `apply_chat_template(..., return_assistant_tokens_mask=True)` emits a
warning and returns an all-zero mask rather than raising:

    return_assistant_tokens_mask==True but chat template does not contain
    `{% generation %}` keyword.

The run then trains with `assistant_only_loss` (or `completion_only_loss`) over
zero supervised tokens. Nothing fails, and the loss curve still looks
reasonable, so the only symptom is a model that did not learn.

Measured on one row with a single-token assistant reply:

| tokenizer | unmasked label positions |
|---|---:|
| LiquidAI/LFM2.5-230M | 3 |
| google gemma-4-31B-it | 0 |

LFM checkpoints ship templates with the markers, so this does not bite the
common path -- it bites when a non-LFM backbone is trained through the same
code. It is also worst for short targets: a single-answer-token SFT contract
has no metric that can reveal it.

This raises when the mask is empty for a row that was not truncated.
Truncation can legitimately cut the assistant span off a long row, and
`drop_overlength` already covers that case, so truncated rows are left alone.

Tests: three added to `tests/math/test_sft_loss_masks.py` covering the
assistant-mask path, the completion-mask path, and the truncated row that must
still be allowed through. Full file passes (11 tests).
