### PR TITLE
fix(training): normalize eval loss by global token count in multi-GPU SFT

### DIFF
--- a/src/leap_finetune/training/utils/causal_lm_loss.py
+++ b/src/leap_finetune/training/utils/causal_lm_loss.py
@@ -200,7 +200,6 @@ def install_memory_efficient_causal_lm_loss(model: nn.Module) -> None:
     def memory_efficient_forward(self, *args, **kwargs):
         labels = kwargs.get("labels")
         logits_to_keep = kwargs.get("logits_to_keep", 0)
-        num_items_in_batch = kwargs.pop("num_items_in_batch", None)
 
         if (
             labels is None
@@ -208,7 +207,15 @@ def install_memory_efficient_causal_lm_loss(model: nn.Module) -> None:
             or args
             or logits_to_keep not in (0, None)
         ):
+            # Keep ``num_items_in_batch`` in kwargs: the stock forward hands it
+            # to ``model.loss_function`` so the loss stays normalized by the
+            # global token count gathered by the trainer. Dropping it here made
+            # eval fall back to a local per-token mean, which the trainer then
+            # scaled by the process count, inflating eval_loss by the world
+            # size on multi-GPU runs.
             return original_forward(*args, **kwargs)
+
+        num_items_in_batch = kwargs.pop("num_items_in_batch", None)
 
         model_kwargs = {
             key: value

--- a/tests/math/test_causal_lm_loss.py
+++ b/tests/math/test_causal_lm_loss.py
@@ -1,0 +1,176 @@
+import torch
+import torch.nn as nn
+
+import leap_finetune.training.utils.causal_lm_loss as causal_lm_loss_module
+from leap_finetune.training.utils.causal_lm_loss import (
+    install_memory_efficient_causal_lm_loss,
+)
+
+VOCAB_SIZE = 16
+HIDDEN_SIZE = 8
+IGNORE_INDEX = -100
+
+
+class _FakeBaseModelOutput:
+    def __init__(self, last_hidden_state: torch.Tensor):
+        self.last_hidden_state = last_hidden_state
+
+
+class _FakeBaseModel(nn.Module):
+    """Stand-in for the transformers base model returning hidden states."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(VOCAB_SIZE, HIDDEN_SIZE)
+
+    def forward(self, input_ids: torch.Tensor, **kwargs) -> _FakeBaseModelOutput:
+        del kwargs
+        return _FakeBaseModelOutput(self.embed(input_ids))
+
+
+class _FakeCausalLM(nn.Module):
+    """Mimics a transformers causal LM: forwards extra kwargs (including
+    ``num_items_in_batch``) to ``self.loss_function``, as stock model
+    forwards do."""
+
+    def __init__(self):
+        super().__init__()
+        self.model = _FakeBaseModel()
+        self.lm_head = nn.Linear(HIDDEN_SIZE, VOCAB_SIZE, bias=False)
+
+    def get_output_embeddings(self) -> nn.Linear:
+        return self.lm_head
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        **kwargs,
+    ) -> dict:
+        del logits_to_keep
+        outputs = self.model(input_ids=input_ids)
+        logits = self.lm_head(outputs.last_hidden_state)
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=VOCAB_SIZE, **kwargs
+            )
+        return {"loss": loss, "logits": logits}
+
+
+def _make_batch() -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, VOCAB_SIZE, (2, 6))
+    labels = input_ids.clone()
+    labels[0, :3] = IGNORE_INDEX
+    return input_ids, labels
+
+
+def _reference_sum_ce(model: _FakeCausalLM, input_ids, labels) -> torch.Tensor:
+    """Summed cross-entropy over valid (shifted) label positions."""
+    logits = model.lm_head(model.model(input_ids=input_ids).last_hidden_state)
+    shift_labels = nn.functional.pad(labels, (0, 1), value=IGNORE_INDEX)[..., 1:]
+    return nn.functional.cross_entropy(
+        logits.view(-1, VOCAB_SIZE).float(),
+        shift_labels.reshape(-1),
+        reduction="sum",
+        ignore_index=IGNORE_INDEX,
+    )
+
+
+def _local_valid_tokens(labels: torch.Tensor) -> torch.Tensor:
+    shift_labels = nn.functional.pad(labels, (0, 1), value=IGNORE_INDEX)[..., 1:]
+    return (shift_labels != IGNORE_INDEX).sum()
+
+
+def test_eval_forward_normalizes_by_global_token_count():
+    """Eval-mode forward must divide by the trainer-provided global token
+    count (gathered across processes), not the local per-rank mean.
+    Otherwise the trainer's ``loss *= num_processes`` correction inflates
+    eval_loss by the world size."""
+    model = _FakeCausalLM()
+    install_memory_efficient_causal_lm_loss(model)
+    model.eval()
+
+    input_ids, labels = _make_batch()
+    local_items = _local_valid_tokens(labels)
+
+    # Simulate a 4-process run: the gathered global count is 4x the local one.
+    world_size = 4
+    num_items_in_batch = local_items * world_size
+
+    with torch.no_grad():
+        output = model(
+            input_ids=input_ids,
+            labels=labels,
+            num_items_in_batch=num_items_in_batch,
+        )
+
+    expected = _reference_sum_ce(model, input_ids, labels) / num_items_in_batch
+    torch.testing.assert_close(output["loss"], expected)
+
+
+def test_eval_forward_without_num_items_uses_local_mean():
+    model = _FakeCausalLM()
+    install_memory_efficient_causal_lm_loss(model)
+    model.eval()
+
+    input_ids, labels = _make_batch()
+    local_items = _local_valid_tokens(labels)
+
+    with torch.no_grad():
+        output = model(input_ids=input_ids, labels=labels)
+
+    expected = _reference_sum_ce(model, input_ids, labels) / local_items
+    torch.testing.assert_close(output["loss"], expected)
+
+
+def test_train_forward_normalizes_by_global_token_count(monkeypatch):
+    monkeypatch.setattr(causal_lm_loss_module, "_LOSS_BACKEND", "eager")
+    model = _FakeCausalLM()
+    install_memory_efficient_causal_lm_loss(model)
+    model.train()
+
+    input_ids, labels = _make_batch()
+    local_items = _local_valid_tokens(labels)
+
+    world_size = 4
+    num_items_in_batch = local_items * world_size
+
+    output = model(
+        input_ids=input_ids,
+        labels=labels,
+        num_items_in_batch=num_items_in_batch,
+    )
+
+    expected = _reference_sum_ce(model, input_ids, labels) / num_items_in_batch
+    torch.testing.assert_close(output["loss"], expected)
+
+
+def test_train_and_eval_forward_agree(monkeypatch):
+    """Same inputs and same global token count must yield the same loss in
+    training and eval mode."""
+    monkeypatch.setattr(causal_lm_loss_module, "_LOSS_BACKEND", "eager")
+    model = _FakeCausalLM()
+    install_memory_efficient_causal_lm_loss(model)
+
+    input_ids, labels = _make_batch()
+    num_items_in_batch = _local_valid_tokens(labels) * 8
+
+    model.train()
+    train_loss = model(
+        input_ids=input_ids,
+        labels=labels,
+        num_items_in_batch=num_items_in_batch,
+    )["loss"]
+
+    model.eval()
+    with torch.no_grad():
+        eval_loss = model(
+            input_ids=input_ids,
+            labels=labels,
+            num_items_in_batch=num_items_in_batch,
+        )["loss"]
+
+    torch.testing.assert_close(eval_loss, train_loss.detach())


### PR DESCRIPTION
## Problem

In multi-GPU SFT runs, `eval_loss` is inflated by exactly the world size. Training loss is unaffected.

## Mechanism

- The patched `memory_efficient_forward` in `src/leap_finetune/training/utils/causal_lm_loss.py` pops `num_items_in_batch` from kwargs and, in eval mode (`not self.training`), delegates to the stock forward with the kwarg dropped — so `model.loss_function` (`chunked_causal_lm_loss`) falls back to a local per-token mean.
- transformers 5.3 `Trainer.prediction_step` computes `num_items_in_batch` and gathers it globally (`average_tokens_across_devices` defaults to True), then `compute_loss` applies `loss *= self.accelerator.num_processes` — a correction that assumes the model divided by the global token count.
- In eval that correction has nothing to cancel, so `eval_loss = world_size x true loss`. The training path passes `num_items_in_batch` through to the memory-efficient loss and divides by the gathered global count, so training loss is correct.

## Empirical verification (identical config, wayfair project runs)

| GPUs | train_loss | eval_loss | eval ratio vs 1 GPU |
|------|-----------|-----------|---------------------|
| 1    | 0.6705    | 0.5536    | 1.00x               |
| 8    | 0.6707    | 4.436     | 8.01x               |

2-GPU runs show 2x, 4-GPU runs show 4x.

## Fix

Keep `num_items_in_batch` in kwargs on the delegation path. The stock transformers forward hands `**kwargs` to `model.loss_function`, so the eval loss is normalized by the globally gathered token count and the trainer's `x num_processes` correction cancels — eval loss equals the true global per-token mean, matching training.

DPO/KTO paths are not affected: TRL's `DPOTrainer` overrides `compute_loss` and computes the loss itself, without the `x num_processes` correction.

## Tests

New `tests/math/test_causal_lm_loss.py` exercises the patched forward directly: eval mode with a fake global `num_items_in_batch` (4x local count) must divide by the provided global count, plus train/eval parity for the same inputs. On the unfixed code the eval test reads exactly 4x the expected value and the parity test 8x.

## Note on historical results

All historical multi-GPU SFT `eval_loss` values logged by leap-finetune are scaled by their GPU count. This affects cross-run comparability of eval_loss (e.g. comparing 1-GPU and 8-GPU runs), not training itself.