### PR TITLE
fix(training): align causal LM token counts

### DIFF
--- a/src/leap_finetune/training/moe_sft.py
+++ b/src/leap_finetune/training/moe_sft.py
@@ -35,6 +35,7 @@ from leap_finetune.training.moe_utils.memory_trace import (
     write_memory_trace_event,
 )
 from leap_finetune.training.utils.trainer_mixins import (
+    CausalLMLossTokenCountMixin,
     ManualShardedCheckpointMixin,
     validate_manual_sharded_training_args,
 )
@@ -71,7 +72,9 @@ MOE_SFT_EXCLUDED_KEYS = SFT_EXCLUDED_KEYS | {
 }
 
 
-class LFMMoeSFTTrainer(ManualShardedCheckpointMixin, Trainer):
+class LFMMoeSFTTrainer(
+    CausalLMLossTokenCountMixin, ManualShardedCheckpointMixin, Trainer
+):
     """SFT Trainer for MoE models with EP/FSDP2 support."""
 
     def __init__(

--- a/src/leap_finetune/training/sft.py
+++ b/src/leap_finetune/training/sft.py
@@ -28,6 +28,7 @@ from leap_finetune.training.peft.peft import (
     merge_and_save_peft_model,
 )
 from leap_finetune.training.utils.trainer_mixins import (
+    CausalLMLossTokenCountMixin,
     RayDataLoaderMixin,
 )
 from leap_finetune.training.utils.trainer_lifecycle import (
@@ -63,7 +64,7 @@ class LFMDataCollatorForLanguageModeling(DataCollatorForLanguageModeling):
         return super().torch_call(masked_examples)
 
 
-class LFMSFTTrainer(RayDataLoaderMixin, Trainer):
+class LFMSFTTrainer(RayDataLoaderMixin, CausalLMLossTokenCountMixin, Trainer):
     """SFT trainer with Ray-sharded data loaders."""
 
 

--- a/src/leap_finetune/training/utils/trainer_mixins.py
+++ b/src/leap_finetune/training/utils/trainer_mixins.py
@@ -47,6 +47,28 @@ class RayDataLoaderMixin:
         )
 
 
+class CausalLMLossTokenCountMixin:
+    """Align Trainer token counts with decoder-only causal-LM loss targets.
+
+    Transformers 5.3 counts non-ignored labels before the model shifts them,
+    while the causal loss in this repository scores labels[..., 1:].
+    Passing shifted labels through to the upstream helper preserves its
+    distributed gathering and device handling while keeping the denominator
+    aligned with the scored tokens.
+    """
+
+    def _get_num_items_in_batch(self, batch_samples, device):
+        if not batch_samples or "labels" not in batch_samples[0]:
+            return super()._get_num_items_in_batch(batch_samples, device)
+
+        shifted_samples = []
+        for batch in batch_samples:
+            shifted_batch = dict(batch)
+            shifted_batch["labels"] = batch["labels"][..., 1:]
+            shifted_samples.append(shifted_batch)
+        return super()._get_num_items_in_batch(shifted_samples, device)
+
+
 def validate_manual_sharded_training_args(
     config_kwargs: dict,
     *,


### PR DESCRIPTION
Follow-up to #38.\n\nThe memory-efficient causal loss scores labels[..., 1:], but Transformers token accounting otherwise counts the unshifted labels. Apply the same shift when Trainer computes num_items_in_batch for dense and MoE SFT, preserving upstream distributed gathering and avoiding mutation of the original batch.\n\nValidation:\n- direct token-count mixin smoke check\n- pytest tests/math/test_causal_lm_loss.py -q (4 passed)\n- Ruff check and format\n- git diff --check