### PR TITLE
Make DPO reference precompute Ray-shard aware

### DIFF
--- a/src/leap_finetune/training/dpo.py
+++ b/src/leap_finetune/training/dpo.py
@@ -27,6 +27,7 @@ from leap_finetune.training.peft.peft import (
 )
 from leap_finetune.training.utils.trainer_mixins import (
     RayDataLoaderMixin,
+    RayPrecomputedRefLogpsMixin,
 )
 from leap_finetune.training.utils.trainer_lifecycle import (
     run_training_safely,
@@ -42,7 +43,7 @@ from leap_finetune.training.utils.config_filter import (
 logger = logging.getLogger(__name__)
 
 
-class LFMDPOTrainer(RayDataLoaderMixin, DPOTrainer):
+class LFMDPOTrainer(RayPrecomputedRefLogpsMixin, RayDataLoaderMixin, DPOTrainer):
     """DPO trainer with Ray-sharded data loaders."""
 
     def _prepare_dataset(self, dataset, *args, **kwargs):

--- a/src/leap_finetune/training/moe_dpo.py
+++ b/src/leap_finetune/training/moe_dpo.py
@@ -31,6 +31,7 @@ from leap_finetune.training.utils.logging import (
 from leap_finetune.training.utils.trainer_mixins import (
     ManualShardedCheckpointMixin,
     validate_manual_sharded_training_args,
+    RayPrecomputedRefLogpsMixin,
 )
 from leap_finetune.training.utils.trainer_lifecycle import run_training_safely
 from leap_finetune.training.utils.config_filter import filter_runtime_config_kwargs
@@ -73,7 +74,9 @@ MOE_DPO_EXCLUDED_KEYS = {
 }
 
 
-class LFMMoeDPOTrainer(ManualShardedCheckpointMixin, DPOTrainer):
+class LFMMoeDPOTrainer(
+    RayPrecomputedRefLogpsMixin, ManualShardedCheckpointMixin, DPOTrainer
+):
     """DPO Trainer for MoE models with EP/FSDP2 support."""
 
     def __init__(

--- a/src/leap_finetune/training/utils/trainer_mixins.py
+++ b/src/leap_finetune/training/utils/trainer_mixins.py
@@ -1,7 +1,12 @@
 import logging
+import os
 
 import torch
+
+from accelerate.utils import tqdm
+from datasets import Dataset, IterableDataset
 from torch.utils.data import DataLoader
+from trl.models import prepare_deepspeed
 
 from leap_finetune.data_loading.length_grouping import (
     get_length_grouped_sampler,
@@ -105,6 +110,60 @@ class RayDataLoaderMixin:
             collate_fn=self.data_collator,
             **self._ray_dataloader_kwargs(training=False),
         )
+
+
+class RayPrecomputedRefLogpsMixin:
+    """Precompute reference log-probs on each already-sharded Ray dataset."""
+
+    def _precompute_ref_logps(
+        self, dataset: Dataset, name: str, batch_size: int
+    ) -> Dataset:
+        if isinstance(dataset, IterableDataset):
+            raise ValueError(
+                "`precompute_ref_log_probs=True` is not supported with IterableDataset. "
+                "Use a map-style dataset or disable precomputation."
+            )
+
+        data_seed = (
+            self.args.data_seed if self.args.data_seed is not None else self.args.seed
+        )
+        dataloader = DataLoader(
+            dataset,
+            batch_size=batch_size,
+            collate_fn=self.data_collator,
+            num_workers=self.args.dataloader_num_workers,
+            pin_memory=self.args.dataloader_pin_memory,
+            shuffle=False,
+            generator=torch.Generator().manual_seed(data_seed),
+        )
+
+        if self.ref_model is None and self.is_deepspeed_enabled:
+            if self._precompute_engine is None:
+                self._precompute_engine = prepare_deepspeed(
+                    self.model, self.accelerator
+                )
+            model = self._precompute_engine
+        else:
+            model = self.ref_model or self.model
+
+        ref_chosen_logps = []
+        ref_rejected_logps = []
+        for padded_batch in tqdm(
+            iterable=dataloader,
+            desc=f"Computing reference log probs for local {name} dataset shard",
+            disable=bool(os.environ.get("TQDM_DISABLE", "")),
+        ):
+            padded_batch = self._prepare_inputs(padded_batch)
+            ref_chosen_logp, ref_rejected_logp = self.compute_ref_log_probs(
+                model, padded_batch
+            )
+            ref_chosen_logps.append(ref_chosen_logp.cpu())
+            ref_rejected_logps.append(ref_rejected_logp.cpu())
+
+        chosen = torch.cat(ref_chosen_logps).float().numpy()
+        rejected = torch.cat(ref_rejected_logps).float().numpy()
+        dataset = dataset.add_column("ref_chosen_logps", chosen)
+        return dataset.add_column("ref_rejected_logps", rejected)
 
 
 class CausalLMLossTokenCountMixin:

--- a/tests/test_dpo_ray_precompute.py
+++ b/tests/test_dpo_ray_precompute.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import torch
+from datasets import Dataset
+
+from leap_finetune.training.utils.trainer_mixins import RayPrecomputedRefLogpsMixin
+
+
+class _LocalShardTrainer(RayPrecomputedRefLogpsMixin):
+    def __init__(self):
+        self.args = SimpleNamespace(
+            dataloader_num_workers=0, dataloader_pin_memory=False, data_seed=42, seed=42
+        )
+        self.ref_model = object()
+        self.model = object()
+        self.is_deepspeed_enabled = False
+        self.data_collator = self._collate
+
+    @staticmethod
+    def _collate(examples):
+        return {
+            "chosen": torch.tensor([example["chosen"] for example in examples]),
+            "rejected": torch.tensor([example["rejected"] for example in examples]),
+        }
+
+    @staticmethod
+    def _prepare_inputs(inputs):
+        return inputs
+
+    @staticmethod
+    def compute_ref_log_probs(model, inputs):
+        return inputs["chosen"], inputs["rejected"]
+
+
+def test_precompute_ref_logps_stays_aligned_with_local_ray_shard(monkeypatch):
+    monkeypatch.setenv("TQDM_DISABLE", "1")
+    local_shard = Dataset.from_dict(
+        {
+            "sample_id": [11, 37, 52],
+            "chosen": [-11.5, -37.5, -52.5],
+            "rejected": [-12.5, -38.5, -53.5],
+        }
+    )
+
+    torch.manual_seed(1234)
+    expected_rng_values = torch.rand(4)
+    torch.manual_seed(1234)
+
+    result = _LocalShardTrainer()._precompute_ref_logps(
+        local_shard, "train", batch_size=2
+    )
+
+    assert result["sample_id"] == [11, 37, 52]
+    assert result["ref_chosen_logps"] == [-11.5, -37.5, -52.5]
+    assert result["ref_rejected_logps"] == [-12.5, -38.5, -53.5]
+    assert torch.equal(torch.rand(4), expected_rng_values)


### PR DESCRIPTION
## Summary

- precompute DPO reference log-probabilities independently on each Ray-local dataset shard
- avoid Accelerate preparing and sharding an already Ray-sharded DataLoader a second time
- preserve global RNG state with a private seeded DataLoader generator
- enable the same behavior for dense and MoE DPO trainers

This is the Leap-specific integration required for optional `precompute_ref_log_probs=True`. Plain Liger training remains unchanged. Generic TRL assumes every rank starts from the same dataset and can share a rank-0 cache; Leap workers instead receive different Ray-local shards and local row indices, so the generic path can attach rank-0 scores to rank-1 examples.

Vision DPO remains unsupported because TRL performs its dynamic multimodal preprocessing on the fly rather than producing a map-style tokenized dataset suitable for this cache.

Upstream dependencies:

- huggingface/trl#7084
- linkedin/Liger-Kernel#1317

## Validation

- `tests/test_dpo_ray_precompute.py`: passed on current `main`
- verifies local row/log-prob alignment
- verifies precomputation does not alter subsequent PyTorch RNG values