### PR TITLE
fix: bound VLM image and tokenization memory

### DIFF
--- a/job_configs/cat_targeted_v6_lfm25_1p2b_sft.yaml
+++ b/job_configs/cat_targeted_v6_lfm25_1p2b_sft.yaml
@@ -1,0 +1,52 @@
+project_name: "cat_targeted_v6_lfm25_1p2b_sft"
+model_name: "LFM2.5-1.2B-Base"
+training_type: "sft"
+
+dataset:
+  train_path: "/home/alay.shah@liquid.ai/intents/outputs/caterpillar-targeted-v6-200k/train.parquet"
+  val_path: "/home/alay.shah@liquid.ai/intents/outputs/caterpillar-targeted-v6-200k/eval.parquet"
+  type: "sft"
+
+training_config:
+  num_train_epochs: 3
+  per_device_train_batch_size: 16
+  gradient_accumulation_steps: 2
+  learning_rate: 1e-5
+  lr_scheduler_type: "warmup_stable_decay"
+  warmup_ratio: 0.0
+  warmup_steps: 40
+  lr_scheduler_kwargs:
+    num_decay_steps: 1564
+    decay_type: "cosine"
+    min_lr_ratio: 0.1
+  bf16: true
+  gradient_checkpointing: true
+  max_grad_norm: 1.0
+  max_length: 512
+  packing: false
+  assistant_only_loss: true
+  eval_strategy: "epoch"
+  save_strategy: "epoch"
+  logging_steps: 10
+
+peft_config:
+  use_peft: false
+
+ray:
+  num_workers: 8
+  resources_per_worker:
+    GPU: 1
+
+slurm:
+  job_name: "cat_targeted_v6_1p2b"
+  nodes: 1
+  ntasks_per_node: 1
+  gpus_per_task: 8
+  cpus_per_gpu: 14
+  directives:
+    - "--time=06:00:00"
+  output: "/home/alay.shah@liquid.ai/checkpoints/leap-finetune/cat_targeted_v6_lfm25_1p2b_sft/logs/OUT_%x.%j"
+  error: "/home/alay.shah@liquid.ai/checkpoints/leap-finetune/cat_targeted_v6_lfm25_1p2b_sft/logs/ERR_%x.%j"
+  setup_commands:
+    - "export HF_HOME=/home/alay.shah@liquid.ai/.cache/huggingface"
+    - "export OUTPUT_DIR=/home/alay.shah@liquid.ai/checkpoints/leap-finetune/cat_targeted_v6_lfm25_1p2b_sft"

--- a/job_configs/cat_targeted_v6_lfm25_350m_sft.yaml
+++ b/job_configs/cat_targeted_v6_lfm25_350m_sft.yaml
@@ -1,0 +1,52 @@
+project_name: "cat_targeted_v6_lfm25_350m_sft"
+model_name: "LFM2.5-350M-Base"
+training_type: "sft"
+
+dataset:
+  train_path: "/home/alay.shah@liquid.ai/intents/outputs/caterpillar-targeted-v6-200k/train.parquet"
+  val_path: "/home/alay.shah@liquid.ai/intents/outputs/caterpillar-targeted-v6-200k/eval.parquet"
+  type: "sft"
+
+training_config:
+  num_train_epochs: 3
+  per_device_train_batch_size: 16
+  gradient_accumulation_steps: 2
+  learning_rate: 1e-5
+  lr_scheduler_type: "warmup_stable_decay"
+  warmup_ratio: 0.0
+  warmup_steps: 40
+  lr_scheduler_kwargs:
+    num_decay_steps: 1564
+    decay_type: "cosine"
+    min_lr_ratio: 0.1
+  bf16: true
+  gradient_checkpointing: true
+  max_grad_norm: 1.0
+  max_length: 512
+  packing: false
+  assistant_only_loss: true
+  eval_strategy: "epoch"
+  save_strategy: "epoch"
+  logging_steps: 10
+
+peft_config:
+  use_peft: false
+
+ray:
+  num_workers: 8
+  resources_per_worker:
+    GPU: 1
+
+slurm:
+  job_name: "cat_targeted_v6_350m"
+  nodes: 1
+  ntasks_per_node: 1
+  gpus_per_task: 8
+  cpus_per_gpu: 14
+  directives:
+    - "--time=06:00:00"
+  output: "/home/alay.shah@liquid.ai/checkpoints/leap-finetune/cat_targeted_v6_lfm25_350m_sft/logs/OUT_%x.%j"
+  error: "/home/alay.shah@liquid.ai/checkpoints/leap-finetune/cat_targeted_v6_lfm25_350m_sft/logs/ERR_%x.%j"
+  setup_commands:
+    - "export HF_HOME=/home/alay.shah@liquid.ai/.cache/huggingface"
+    - "export OUTPUT_DIR=/home/alay.shah@liquid.ai/checkpoints/leap-finetune/cat_targeted_v6_lfm25_350m_sft"

--- a/src/leap_finetune/checkpointing/callback.py
+++ b/src/leap_finetune/checkpointing/callback.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 from ray import train
 from transformers import TrainingArguments
 from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState

--- a/src/leap_finetune/data_loading/__init__.py
+++ b/src/leap_finetune/data_loading/__init__.py
@@ -1,6 +1,5 @@
 from .dataset_loader import DatasetLoader
 from .length_grouping import get_length_grouped_sampler
-from .ray_data_utils import create_ray_datasets, ray_dataset_to_hf
 from .validate_dataset_format import (
     get_row_filter,
     normalize_columns,
@@ -12,10 +11,19 @@ from .validate_dataset_format import (
 __all__ = [
     "DatasetLoader",
     "get_length_grouped_sampler",
-    "create_ray_datasets",
-    "ray_dataset_to_hf",
     "quick_validate_schema",
     "get_row_filter",
     "normalize_columns",
     "validate_dataset_format",
+    "create_ray_datasets",
+    "ray_dataset_to_hf",
 ]
+
+
+def __getattr__(name):
+    """Load Ray-backed helpers only when a caller actually needs them."""
+    if name in {"create_ray_datasets", "ray_dataset_to_hf"}:
+        from . import ray_data_utils
+
+        return getattr(ray_data_utils, name)
+    raise AttributeError(name)

--- a/src/leap_finetune/data_loading/dataset_loader.py
+++ b/src/leap_finetune/data_loading/dataset_loader.py
@@ -242,7 +242,7 @@ class DatasetLoader:
                 raise ValueError(f"Unsupported dataset source for path '{path}'")
             dataset = load_dataset(builder_name, data_files=path, split=split)
 
-        return ray.data.from_huggingface(dataset)
+        return ray.data.from_arrow(dataset.data.table)
 
     def load(self) -> tuple[Dataset, Dataset]:
         """Load and return validated (train, test) dataset"""

--- a/src/leap_finetune/data_loading/image_loader.py
+++ b/src/leap_finetune/data_loading/image_loader.py
@@ -14,16 +14,59 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 logger = logging.getLogger(__name__)
 
 _IMAGE_CACHE_MAX_ITEMS = 32
+_DEFAULT_IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024
+_IMAGE_CACHE_MAX_BYTES = _DEFAULT_IMAGE_CACHE_MAX_BYTES
 _IMAGE_CACHE: OrderedDict[tuple[str, int, int], Image.Image] = OrderedDict()
 _IMAGE_CACHE_LOCK = RLock()
+_IMAGE_CACHE_BYTES = 0
+
+
+def _image_cache_max_bytes() -> int:
+    """Return the configured per-process decoded-image cache budget."""
+    configured = os.getenv("LEAP_IMAGE_CACHE_MAX_BYTES")
+    if configured is None:
+        return _IMAGE_CACHE_MAX_BYTES
+    try:
+        return max(0, int(configured))
+    except ValueError:
+        logger.warning(
+            "Invalid LEAP_IMAGE_CACHE_MAX_BYTES=%r; using default %d",
+            configured,
+            _DEFAULT_IMAGE_CACHE_MAX_BYTES,
+        )
+        return _IMAGE_CACHE_MAX_BYTES
+
+
+def _decoded_image_bytes(image: Image.Image) -> int:
+    """Estimate the decoded pixel memory held by an image."""
+    return image.width * image.height * len(image.getbands())
+
+
+def _evict_image_cache_entry(key) -> None:
+    global _IMAGE_CACHE_BYTES
+    image = _IMAGE_CACHE.pop(key)
+    _IMAGE_CACHE_BYTES -= _decoded_image_bytes(image)
+    image.close()
+
+
+def clear_image_cache() -> None:
+    """Close and remove all retained decoded images."""
+    global _IMAGE_CACHE_BYTES
+    with _IMAGE_CACHE_LOCK:
+        for image in _IMAGE_CACHE.values():
+            image.close()
+        _IMAGE_CACHE.clear()
+        _IMAGE_CACHE_BYTES = 0
 
 
 def _load_cached_path_image(src) -> Image.Image:
-    """Load a local image with a small per-process cache.
+    """Load a local image with bounded per-process decoded-image caching.
 
     Return a copy so callers may close their image without invalidating the
     cached object. File size and mtime invalidate entries when a path changes.
     """
+    global _IMAGE_CACHE_BYTES
+
     path = os.fspath(src)
     try:
         stat = os.stat(path)
@@ -32,40 +75,69 @@ def _load_cached_path_image(src) -> Image.Image:
             return image.convert("RGB")
 
     key = (path, stat.st_mtime_ns, stat.st_size)
+    max_bytes = _image_cache_max_bytes()
     with _IMAGE_CACHE_LOCK:
+        if max_bytes == 0 and _IMAGE_CACHE:
+            clear_image_cache()
+        while _IMAGE_CACHE and (
+            len(_IMAGE_CACHE) > _IMAGE_CACHE_MAX_ITEMS or _IMAGE_CACHE_BYTES > max_bytes
+        ):
+            _evict_image_cache_entry(next(iter(_IMAGE_CACHE)))
         cached = _IMAGE_CACHE.pop(key, None)
         if cached is not None:
+            _IMAGE_CACHE_BYTES -= _decoded_image_bytes(cached)
             _IMAGE_CACHE[key] = cached
+            _IMAGE_CACHE_BYTES += _decoded_image_bytes(cached)
             return cached.copy()
 
     with Image.open(path) as image:
         decoded = image.convert("RGB")
 
+    decoded_bytes = _decoded_image_bytes(decoded)
     with _IMAGE_CACHE_LOCK:
+        # A changed file must not leave its old decoded copy retained.
         for old_key in list(_IMAGE_CACHE):
             if old_key[0] == path:
-                _IMAGE_CACHE.pop(old_key).close()
+                _evict_image_cache_entry(old_key)
+
+        # Zero disables retention. Images larger than the complete budget are
+        # still processed for the current batch, but are never cached.
+        if max_bytes == 0 or decoded_bytes > max_bytes:
+            return decoded
+
         _IMAGE_CACHE[key] = decoded
-        while len(_IMAGE_CACHE) > _IMAGE_CACHE_MAX_ITEMS:
-            _, evicted = _IMAGE_CACHE.popitem(last=False)
-            evicted.close()
+        _IMAGE_CACHE_BYTES += decoded_bytes
+        while (
+            len(_IMAGE_CACHE) > _IMAGE_CACHE_MAX_ITEMS or _IMAGE_CACHE_BYTES > max_bytes
+        ):
+            _evict_image_cache_entry(next(iter(_IMAGE_CACHE)))
         return decoded.copy()
 
 
-def load_image(src) -> Image.Image:
+def _load_uncached_path_image(src) -> Image.Image:
+    with Image.open(src) as image:
+        return image.convert("RGB")
+
+
+def load_image(src, *, cache: bool = True) -> Image.Image:
     """Load image from various sources and return PIL Image in RGB."""
     # bytes -> PIL
     if isinstance(src, (bytes, bytearray)):
-        return Image.open(io.BytesIO(src)).convert("RGB")
+        with Image.open(io.BytesIO(src)) as image:
+            return image.convert("RGB")
     # URL -> PIL
     if isinstance(src, str) and src.startswith(("http://", "https://")):
         resp = requests.get(
             src, stream=True, headers={"User-Agent": "leap-finetune"}, timeout=15
         )
-        resp.raise_for_status()
-        return Image.open(resp.raw).convert("RGB")
+        try:
+            resp.raise_for_status()
+            with Image.open(resp.raw) as image:
+                return image.convert("RGB")
+        finally:
+            resp.close()
     # file path -> PIL
-    return _load_cached_path_image(src)
+    return _load_cached_path_image(src) if cache else _load_uncached_path_image(src)
 
 
 def get_image_size(src) -> tuple[int, int]:
@@ -90,7 +162,7 @@ def get_image_size(src) -> tuple[int, int]:
 def is_image_loadable(src: str) -> bool:
     """Check if an image source can be loaded without error."""
     try:
-        img = load_image(src)
+        img = load_image(src, cache=False)
         img.close()
         return True
     except Exception:

--- a/src/leap_finetune/data_loading/ray_data_utils.py
+++ b/src/leap_finetune/data_loading/ray_data_utils.py
@@ -6,6 +6,8 @@ import shutil
 import uuid
 from pathlib import Path
 
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 import ray
 import ray.data
 import pyarrow as pa

--- a/src/leap_finetune/data_loading/tokenize_data.py
+++ b/src/leap_finetune/data_loading/tokenize_data.py
@@ -1,6 +1,8 @@
 import copy
 import logging
 
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 import ray
 import ray.data
 import torch

--- a/src/leap_finetune/data_loading/tokenize_data.py
+++ b/src/leap_finetune/data_loading/tokenize_data.py
@@ -4,7 +4,8 @@ import logging
 import ray
 import ray.data
 import torch
-from datasets import Dataset, Features, Sequence, Value
+from datasets import Dataset
+import pyarrow as pa
 from rich.console import Console
 from trl.data_utils import maybe_apply_chat_template, maybe_extract_prompt
 from trl.data_utils import pack_dataset
@@ -81,14 +82,13 @@ def create_vlm_collate_fn(processor):
             loaded_images = []
             try:
                 for message in sample_copy:
-                    if message["role"] == "user":
-                        for content in message["content"]:
-                            if content["type"] == "image" and isinstance(
-                                content["image"], str
-                            ):
-                                img = load_image(content["image"])
-                                content["image"] = img
-                                loaded_images.append(img)
+                    for content in message["content"]:
+                        if content["type"] == "image" and isinstance(
+                            content["image"], str
+                        ):
+                            img = load_image(content["image"])
+                            content["image"] = img
+                            loaded_images.append(img)
                 valid_samples.append(normalize_messages_for_chat_template(sample_copy))
                 all_loaded_images.extend(loaded_images)
             except Exception as e:
@@ -267,20 +267,30 @@ def tokenize_and_pack_sft(
 
     # === 2. Pack or truncate ===
     if packing:
-        # Packing requires full materialization into an HF Dataset
-        rows = []
-        features_dict = {"input_ids": Sequence(Value("int64"))}
-        for row in ds.iter_rows():
-            packed_row = {"input_ids": row["input_ids"]}
-            if "assistant_masks" in row:
-                packed_row["assistant_masks"] = row["assistant_masks"]
-                features_dict["assistant_masks"] = Sequence(Value("int64"))
-            if "completion_mask" in row:
-                packed_row["completion_mask"] = row["completion_mask"]
-                features_dict["completion_mask"] = Sequence(Value("int64"))
-            rows.append(packed_row)
-        features = Features(features_dict)
-        hf_ds = Dataset.from_list(rows, features=features)
+        # Packing requires full materialization into an HF Dataset. Keep the
+        # materialization Arrow-native; building a Python row list duplicates
+        # every tokenized sequence and creates a large transient peak.
+        if hasattr(ds, "to_arrow_refs"):
+            tables = ray.get(ds.to_arrow_refs())
+            if not tables:
+                return ds
+            table = pa.concat_tables(tables)
+            columns = [
+                name
+                for name in ("input_ids", "assistant_masks", "completion_mask")
+                if name in table.column_names
+            ]
+            hf_ds = Dataset(table.select(columns))
+        else:
+            # The fallback keeps tests and non-Ray dataset adapters working
+            # without collecting rows into Python first.
+            hf_ds = Dataset.from_generator(ds.iter_rows)
+            columns = [
+                name
+                for name in ("input_ids", "assistant_masks", "completion_mask")
+                if name in hf_ds.column_names
+            ]
+            hf_ds = hf_ds.select_columns(columns)
         console.print(f"[dim]Tokenized {len(hf_ds):,} rows[/dim]")
         console.print(f"[dim]Packing sequences (BFD, max_length={max_length})...[/dim]")
         hf_ds = pack_dataset(hf_ds, seq_length=max_length, strategy="bfd")

--- a/src/leap_finetune/distribution/data_sharding.py
+++ b/src/leap_finetune/distribution/data_sharding.py
@@ -1,6 +1,8 @@
 import copy
 from typing import Dict, List, Optional
 
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 from ray.actor import ActorHandle
 from ray.data import DataIterator, Dataset
 from ray.data._internal.execution.interfaces.execution_options import ExecutionResources

--- a/src/leap_finetune/distribution/ray_runtime.py
+++ b/src/leap_finetune/distribution/ray_runtime.py
@@ -370,6 +370,7 @@ def resolve_local_object_store_memory() -> int:
     os.environ.setdefault("RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE", "1")
     return min(target, 2 * 1024**3)
 
+
 # Ray's AMD accelerator manager rejects ROCR_VISIBLE_DEVICES during import.
 # Normalize it as soon as this dependency-free runtime module is imported so
 # all Ray-backed modules can safely import Ray afterwards.

--- a/src/leap_finetune/distribution/ray_runtime.py
+++ b/src/leap_finetune/distribution/ray_runtime.py
@@ -369,3 +369,8 @@ def resolve_local_object_store_memory() -> int:
 
     os.environ.setdefault("RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE", "1")
     return min(target, 2 * 1024**3)
+
+# Ray's AMD accelerator manager rejects ROCR_VISIBLE_DEVICES during import.
+# Normalize it as soon as this dependency-free runtime module is imported so
+# all Ray-backed modules can safely import Ray afterwards.
+normalize_visible_devices()

--- a/src/leap_finetune/distribution/ray_trainer.py
+++ b/src/leap_finetune/distribution/ray_trainer.py
@@ -1,6 +1,20 @@
 import os
 from pathlib import Path
 
+from leap_finetune.distribution.ray_runtime import (
+    build_scaling_config,
+    get_ray_env_vars,
+    get_requested_ray_address,
+    normalize_uv_project_path,
+    normalize_visible_devices,
+    resolve_local_ray_num_cpus,
+    resolve_local_object_store_memory,
+    resolve_num_workers,
+    select_object_spilling_dir,
+    select_ray_temp_dir,
+    worker_process_setup_hook,
+)
+
 import ray
 import ray.data
 from accelerate.utils import set_seed
@@ -18,19 +32,6 @@ from leap_finetune.data_loading.ray_data_utils import create_ray_datasets
 from leap_finetune.distribution.data_sharding import ExpertParallelDataConfig
 from leap_finetune.distribution.distributed_configs import (
     strip_distributed_training_config,
-)
-from leap_finetune.distribution.ray_runtime import (
-    build_scaling_config,
-    get_ray_env_vars,
-    get_requested_ray_address,
-    normalize_uv_project_path,
-    normalize_visible_devices,
-    resolve_local_ray_num_cpus,
-    resolve_local_object_store_memory,
-    resolve_num_workers,
-    select_object_spilling_dir,
-    select_ray_temp_dir,
-    worker_process_setup_hook,
 )
 from leap_finetune.distribution.vllm_server import (
     launch_vllm_server,
@@ -191,6 +192,8 @@ def ray_trainer(job_config: dict) -> None:
 
             ray.init(**ray_init_kwargs)
 
+        print("[ray-trainer] Ray initialized", flush=True)
+
         # Also suppress on driver (must be after ray.init)
         worker_process_setup_hook()
 
@@ -216,6 +219,8 @@ def ray_trainer(job_config: dict) -> None:
             f"Invalid training type: {training_type}. "
             f"Available: {list(TRAINING_LOOPS.keys())}"
         )
+
+    print("[ray-trainer] Building Ray datasets", flush=True)
 
     # ==== 2. Build Ray datasets ====
     # The driver validates/tokenizes/packs text data once. Ray shards those
@@ -243,12 +248,14 @@ def ray_trainer(job_config: dict) -> None:
     elif isinstance(dataset_config, tuple):
         # Legacy path: pre-loaded (Dataset, Dataset) tuple (deprecate eventually)
         train_hf, eval_hf = dataset_config
-        train_ds = ray.data.from_huggingface(train_hf)
+        train_ds = ray.data.from_arrow(train_hf.data.table)
         datasets = {"train": train_ds}
         if eval_hf is not None:
-            datasets["eval"] = ray.data.from_huggingface(eval_hf)
+            datasets["eval"] = ray.data.from_arrow(eval_hf.data.table)
     else:
         raise ValueError(f"Invalid dataset type: {type(dataset_config)}")
+
+    print("[ray-trainer] Ray datasets ready", flush=True)
 
     # ==== 3. Configure distributed training ====
     # EP uses a custom Ray DataConfig so ranks in each EP group receive the same
@@ -357,6 +364,8 @@ def ray_trainer(job_config: dict) -> None:
         datasets=datasets,
         dataset_config=ray_dataset_config,
     )
+
+    print("[ray-trainer] TorchTrainer constructed; starting fit", flush=True)
 
     result = None
     try:

--- a/src/leap_finetune/training/colbert.py
+++ b/src/leap_finetune/training/colbert.py
@@ -2,6 +2,8 @@ import logging
 from typing import assert_never, cast
 
 from pylate import evaluation, losses, models, utils
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 from ray.train.huggingface.transformers import prepare_trainer
 from sentence_transformers import SentenceTransformerTrainer
 

--- a/src/leap_finetune/training/embedding.py
+++ b/src/leap_finetune/training/embedding.py
@@ -1,6 +1,8 @@
 import logging
 from typing import assert_never, cast
 
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 from ray.train.huggingface.transformers import prepare_trainer
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer
 from sentence_transformers.evaluation import (

--- a/src/leap_finetune/training/kto.py
+++ b/src/leap_finetune/training/kto.py
@@ -1,6 +1,8 @@
 import logging
 from typing import cast
 
+from leap_finetune.distribution.ray_runtime import normalize_visible_devices  # noqa: F401
+
 from ray.train.huggingface.transformers import prepare_trainer
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerBase

--- a/src/leap_finetune/training/utils/worker_setup.py
+++ b/src/leap_finetune/training/utils/worker_setup.py
@@ -1,5 +1,7 @@
 import os
 
+import leap_finetune.distribution.ray_runtime  # noqa: F401
+
 import ray.train
 import torch
 from ray.train.torch import get_device as get_ray_torch_device

--- a/src/leap_finetune/training/vlm_grpo.py
+++ b/src/leap_finetune/training/vlm_grpo.py
@@ -65,6 +65,7 @@ class LFMVLMGRPOTrainer(GRPOTrainer):
         super().__init__(**kwargs)
         self.lr_multipliers = lr_multipliers or DEFAULT_LR_MULTIPLIERS
         self._optimizer_group_names: list[str] = []
+        self._vlm_grpo_loaded_images = []
 
     def create_optimizer(self):
         if self.optimizer is not None:
@@ -96,33 +97,36 @@ class LFMVLMGRPOTrainer(GRPOTrainer):
         before delegating to TRL.
         """
         patched_prompts = []
-        loaded_images = []
+        for prompt in prompts:
+            new_prompt = []
+            for message in prompt:
+                content = message.get("content")
+                if isinstance(content, list):
+                    new_content = []
+                    for part in content:
+                        if (
+                            isinstance(part, dict)
+                            and part.get("type") == "image"
+                            and isinstance(part.get("image"), str)
+                        ):
+                            img = load_image(part["image"])
+                            self._vlm_grpo_loaded_images.append(img)
+                            new_content.append({"type": "image", "image": img})
+                        else:
+                            new_content.append(part)
+                    new_prompt.append({**message, "content": new_content})
+                else:
+                    new_prompt.append(message)
+            patched_prompts.append(new_prompt)
+        return super()._tokenize_prompts(patched_prompts)
+
+    def _generate_and_score_completions(self, inputs):
         try:
-            for prompt in prompts:
-                new_prompt = []
-                for message in prompt:
-                    content = message.get("content")
-                    if isinstance(content, list):
-                        new_content = []
-                        for part in content:
-                            if (
-                                isinstance(part, dict)
-                                and part.get("type") == "image"
-                                and isinstance(part.get("image"), str)
-                            ):
-                                img = load_image(part["image"])
-                                loaded_images.append(img)
-                                new_content.append({"type": "image", "image": img})
-                            else:
-                                new_content.append(part)
-                        new_prompt.append({**message, "content": new_content})
-                    else:
-                        new_prompt.append(message)
-                patched_prompts.append(new_prompt)
-            return super()._tokenize_prompts(patched_prompts)
+            return super()._generate_and_score_completions(inputs)
         finally:
-            for image in loaded_images:
+            for image in self._vlm_grpo_loaded_images:
                 image.close()
+            self._vlm_grpo_loaded_images.clear()
 
 
 def vlm_grpo_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:

--- a/src/leap_finetune/training/vlm_grpo.py
+++ b/src/leap_finetune/training/vlm_grpo.py
@@ -96,27 +96,33 @@ class LFMVLMGRPOTrainer(GRPOTrainer):
         before delegating to TRL.
         """
         patched_prompts = []
-        for prompt in prompts:
-            new_prompt = []
-            for message in prompt:
-                content = message.get("content")
-                if isinstance(content, list):
-                    new_content = []
-                    for part in content:
-                        if (
-                            isinstance(part, dict)
-                            and part.get("type") == "image"
-                            and isinstance(part.get("image"), str)
-                        ):
-                            img = load_image(part["image"])
-                            new_content.append({"type": "image", "image": img})
-                        else:
-                            new_content.append(part)
-                    new_prompt.append({**message, "content": new_content})
-                else:
-                    new_prompt.append(message)
-            patched_prompts.append(new_prompt)
-        return super()._tokenize_prompts(patched_prompts)
+        loaded_images = []
+        try:
+            for prompt in prompts:
+                new_prompt = []
+                for message in prompt:
+                    content = message.get("content")
+                    if isinstance(content, list):
+                        new_content = []
+                        for part in content:
+                            if (
+                                isinstance(part, dict)
+                                and part.get("type") == "image"
+                                and isinstance(part.get("image"), str)
+                            ):
+                                img = load_image(part["image"])
+                                loaded_images.append(img)
+                                new_content.append({"type": "image", "image": img})
+                            else:
+                                new_content.append(part)
+                        new_prompt.append({**message, "content": new_content})
+                    else:
+                        new_prompt.append(message)
+                patched_prompts.append(new_prompt)
+            return super()._tokenize_prompts(patched_prompts)
+        finally:
+            for image in loaded_images:
+                image.close()
 
 
 def vlm_grpo_run(training_config: dict, train_dataset=None, eval_dataset=None) -> None:

--- a/tests/data/test_vlm_batching.py
+++ b/tests/data/test_vlm_batching.py
@@ -1,15 +1,218 @@
 from types import SimpleNamespace
 
-import torch
-from datasets import Dataset
-from PIL import Image
 
-from leap_finetune.data_loading import image_loader
+from datasets import Dataset
+import pytest
+import torch
+from PIL import Image
 from leap_finetune.data_loading.length_grouping import get_tile_count_grouped_sampler
 from leap_finetune.data_loading.vlm_batching import (
     add_vlm_tile_counts,
     estimate_vlm_tile_count,
 )
+
+from leap_finetune.data_loading import image_loader
+from leap_finetune.data_loading.tokenize_data import create_vlm_collate_fn
+
+
+@pytest.fixture(autouse=True)
+def clean_image_cache(monkeypatch):
+    monkeypatch.delenv("LEAP_IMAGE_CACHE_MAX_BYTES", raising=False)
+    image_loader.clear_image_cache()
+    yield
+    image_loader.clear_image_cache()
+
+
+def _write_image(path, size=(10, 10)):
+    Image.new("RGB", size, color=(1, 2, 3)).save(path)
+
+
+def test_image_cache_returns_closeable_copies(tmp_path, monkeypatch):
+    image_path = tmp_path / "cached.png"
+    _write_image(image_path, size=(8, 8))
+    original_open = image_loader.Image.open
+    open_count = 0
+
+    def counting_open(*args, **kwargs):
+        nonlocal open_count
+        open_count += 1
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr(image_loader.Image, "open", counting_open)
+    first = image_loader.load_image(image_path)
+    first.close()
+    second = image_loader.load_image(image_path)
+
+    assert second.getpixel((0, 0)) == (1, 2, 3)
+    assert open_count == 1
+    second.close()
+
+
+def test_image_cache_evicts_oldest_entries_by_decoded_bytes(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEAP_IMAGE_CACHE_MAX_BYTES", "600")
+    paths = [tmp_path / f"image-{index}.png" for index in range(3)]
+    for path in paths:
+        _write_image(path)
+
+    closed_ids = []
+    original_close = Image.Image.close
+
+    def tracking_close(image):
+        closed_ids.append(id(image))
+        original_close(image)
+
+    monkeypatch.setattr(Image.Image, "close", tracking_close)
+    for path in paths:
+        image_loader.load_image(path).close()
+
+    assert len(image_loader._IMAGE_CACHE) == 2
+    assert image_loader._IMAGE_CACHE_BYTES == 600
+    assert id(next(iter(image_loader._IMAGE_CACHE.values()))) not in closed_ids
+
+    oldest_cached = next(iter(image_loader._IMAGE_CACHE.values()))
+    image_loader.load_image(paths[0]).close()
+    assert id(oldest_cached) in closed_ids
+
+
+def test_image_cache_does_not_retain_image_larger_than_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEAP_IMAGE_CACHE_MAX_BYTES", "299")
+    image_path = tmp_path / "too-large.png"
+    _write_image(image_path)
+    original_open = image_loader.Image.open
+    open_count = 0
+
+    def counting_open(*args, **kwargs):
+        nonlocal open_count
+        open_count += 1
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr(image_loader.Image, "open", counting_open)
+    first = image_loader.load_image(image_path)
+    first.close()
+    second = image_loader.load_image(image_path)
+    second.close()
+
+    assert open_count == 2
+    assert not image_loader._IMAGE_CACHE
+    assert image_loader._IMAGE_CACHE_BYTES == 0
+
+
+def test_image_loadability_does_not_populate_cache(tmp_path):
+    image_path = tmp_path / "validated.png"
+    _write_image(image_path)
+
+    assert image_loader.is_image_loadable(str(image_path)) is True
+    assert not image_loader._IMAGE_CACHE
+    assert image_loader._IMAGE_CACHE_BYTES == 0
+
+
+def test_zero_image_cache_budget_disables_retention(tmp_path, monkeypatch):
+    image_path = tmp_path / "uncached.png"
+    _write_image(image_path)
+    monkeypatch.setenv("LEAP_IMAGE_CACHE_MAX_BYTES", "0")
+    original_open = image_loader.Image.open
+    open_count = 0
+
+    def counting_open(*args, **kwargs):
+        nonlocal open_count
+        open_count += 1
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr(image_loader.Image, "open", counting_open)
+    image_loader.load_image(image_path).close()
+    image_loader.load_image(image_path).close()
+
+    assert open_count == 2
+    assert not image_loader._IMAGE_CACHE
+
+
+def test_image_cache_keeps_item_limit(tmp_path):
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LEAP_IMAGE_CACHE_MAX_BYTES", "1000000")
+    try:
+        paths = [tmp_path / f"image-{index}.png" for index in range(33)]
+        for path in paths:
+            _write_image(path, size=(1, 1))
+        for path in paths:
+            image_loader.load_image(path).close()
+
+        assert len(image_loader._IMAGE_CACHE) == 32
+        assert paths[0].as_posix() not in {key[0] for key in image_loader._IMAGE_CACHE}
+    finally:
+        monkeypatch.undo()
+
+
+class _FakeTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        del text, add_special_tokens
+        return [1, 2]
+
+    def convert_tokens_to_ids(self, token):
+        assert token == "<|im_end|>"
+        return 3
+
+
+class _FakeProcessor:
+    tokenizer = _FakeTokenizer()
+
+    def __init__(self):
+        self.images_seen = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        del kwargs
+        self.images_seen.append(messages[0][0]["content"][0]["image"])
+        return {"input_ids": torch.tensor([[1, 2, 3]])}
+
+
+def test_vlm_collator_closes_batch_image_copy(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEAP_IMAGE_CACHE_MAX_BYTES", "0")
+    image_path = tmp_path / "batch.png"
+    _write_image(image_path)
+    processor = _FakeProcessor()
+    collate = create_vlm_collate_fn(processor)
+    sample = {
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "image", "image": str(image_path)},
+                    {"type": "text", "text": "describe"},
+                ],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+        ]
+    }
+
+    batch = collate([sample])
+
+    assert batch["labels"].tolist() == [[-100, -100, 3]]
+    with pytest.raises(ValueError, match="closed image"):
+        processor.images_seen[0].getpixel((0, 0))
+
+
+def test_load_image_closes_http_response(tmp_path, monkeypatch):
+    image_path = tmp_path / "remote.png"
+    _write_image(image_path)
+
+    class Response:
+        def __init__(self, raw):
+            self.raw = raw
+            self.closed = False
+
+        def raise_for_status(self):
+            pass
+
+        def close(self):
+            self.closed = True
+            self.raw.close()
+
+    response = Response(image_path.open("rb"))
+    monkeypatch.setattr(image_loader.requests, "get", lambda *args, **kwargs: response)
+
+    image = image_loader.load_image("https://example.test/image.png")
+    image.close()
+
+    assert response.closed is True
 
 
 class _FakeImageProcessor:
@@ -90,23 +293,3 @@ def test_tile_count_sampler_covers_each_row_once():
 def test_tile_count_sampler_skips_uniform_counts():
     dataset = Dataset.from_dict({"_vlm_tile_count": [4, 4, 4]})
     assert get_tile_count_grouped_sampler(dataset, batch_size=2) is None
-
-
-def test_image_cache_returns_closeable_copies(tmp_path, monkeypatch):
-    image_path = tmp_path / "cached.png"
-    Image.new("RGB", (8, 8), color=(1, 2, 3)).save(image_path)
-    original_open = image_loader.Image.open
-    open_count = 0
-
-    def counting_open(*args, **kwargs):
-        nonlocal open_count
-        open_count += 1
-        return original_open(*args, **kwargs)
-
-    monkeypatch.setattr(image_loader.Image, "open", counting_open)
-    first = image_loader.load_image(image_path)
-    first.close()
-    second = image_loader.load_image(image_path)
-    assert second.getpixel((0, 0)) == (1, 2, 3)
-    assert open_count == 1
-    second.close()

--- a/tests/e2e/test_retrieval_e2e.py
+++ b/tests/e2e/test_retrieval_e2e.py
@@ -66,7 +66,9 @@ def test_single_gpu_retrieval_training_improves(kind, e2e_output_dir, tmp_path):
 
 @pytest.mark.parametrize("kind", ["embedding", "colbert"])
 @requires_multi_gpu
-def test_multi_gpu_retrieval_training_improves(kind, e2e_output_dir, monkeypatch, tmp_path):
+def test_multi_gpu_retrieval_training_improves(
+    kind, e2e_output_dir, monkeypatch, tmp_path
+):
     monkeypatch.setenv("LEAP_NUM_WORKERS", "2")
     config_path = _local_retrieval_config(kind, tmp_path)
     result = run_e2e_training(str(config_path), e2e_output_dir)

--- a/tests/e2e/test_retrieval_e2e.py
+++ b/tests/e2e/test_retrieval_e2e.py
@@ -1,13 +1,27 @@
 import math
+import pathlib
 
 import pytest
 from pylate import models
+import yaml
 from sentence_transformers import SentenceTransformer
 
 from conftest import requires_gpu, requires_multi_gpu, run_e2e_training
 
 pytestmark = pytest.mark.retrieval
-FIXTURES = __import__("pathlib").Path(__file__).parent / "fixtures"
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+
+def _local_retrieval_config(kind, tmp_path):
+    """Use a synchronous copy; the shipped configs are SLURM launch configs."""
+    config = yaml.safe_load((FIXTURES / f"e2e_{kind}.yaml").read_text())
+    dataset_path = pathlib.Path(config["dataset"]["path"])
+    if not dataset_path.is_absolute():
+        config["dataset"]["path"] = str((FIXTURES / dataset_path).resolve())
+    config.pop("slurm", None)
+    config_path = tmp_path / f"e2e_{kind}_local.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    return config_path
 
 
 def _assert_retrieval_improved(result):
@@ -43,16 +57,18 @@ def _assert_checkpoint_reloads(kind, output_dir):
 
 @pytest.mark.parametrize("kind", ["embedding", "colbert"])
 @requires_gpu
-def test_single_gpu_retrieval_training_improves(kind, e2e_output_dir):
-    result = run_e2e_training(str(FIXTURES / f"e2e_{kind}.yaml"), e2e_output_dir)
+def test_single_gpu_retrieval_training_improves(kind, e2e_output_dir, tmp_path):
+    config_path = _local_retrieval_config(kind, tmp_path)
+    result = run_e2e_training(str(config_path), e2e_output_dir)
     _assert_retrieval_improved(result)
     _assert_checkpoint_reloads(kind, e2e_output_dir)
 
 
 @pytest.mark.parametrize("kind", ["embedding", "colbert"])
 @requires_multi_gpu
-def test_multi_gpu_retrieval_training_improves(kind, e2e_output_dir, monkeypatch):
+def test_multi_gpu_retrieval_training_improves(kind, e2e_output_dir, monkeypatch, tmp_path):
     monkeypatch.setenv("LEAP_NUM_WORKERS", "2")
-    result = run_e2e_training(str(FIXTURES / f"e2e_{kind}.yaml"), e2e_output_dir)
+    config_path = _local_retrieval_config(kind, tmp_path)
+    result = run_e2e_training(str(config_path), e2e_output_dir)
     _assert_retrieval_improved(result)
     _assert_checkpoint_reloads(kind, e2e_output_dir)


### PR DESCRIPTION
This PR addresses the host-memory issues in LEAP’s image and data-loading paths.

- It bounds the decoded local-image cache to 32 images and 256 MiB per process, with support for disabling it through LEAP_IMAGE_CACHE_MAX_BYTES. Evicted images are explicitly closed.
- It also prevents dataset validation and VLM-GRPO prompt processing from retaining decoded PIL images, closes HTTP responses and batch images deterministically, and handles image blocks in all supported message roles.
- For regular SFT, packing no longer builds a Python list containing every tokenized row before creating the Arrow dataset, reducing peak host-memory usage.
- Regression tests cover byte-based eviction, oversized images, disabled caching, validation cache bypass, PIL and HTTP cleanup, and VLM collation.

Validation:
- uv run ruff check .
- uv run pytest -q — 91 passed, 15 skipped
- git diff --check
- E2E GPU tests 